### PR TITLE
Allow overriding all XHR options, both per request and globally for the adapter instance

### DIFF
--- a/src/any-http-reqwest.js
+++ b/src/any-http-reqwest.js
@@ -19,7 +19,7 @@ function dispatch(method, uri, data, options) {
       method:  method,
       type:    'json',
       data:    data,
-      // FIXME: not for GET though?
+      // Not needed for GET, but reqwest sets a dummy default then anyway...
       // FIXME: or argo?
       contentType:     'application/json',
       headers:         options.headers,

--- a/src/any-http-reqwest.js
+++ b/src/any-http-reqwest.js
@@ -9,7 +9,7 @@ function getHeaders(request) {
   };
 }
 
-function dispatch(method, uri, data) {
+function dispatch(method, uri, data, options) {
   if (typeof uri !== 'string' || uri === '') throw new Error()
 
   // Note: don't use reqwest's promises that are not A+-compliant
@@ -21,14 +21,10 @@ function dispatch(method, uri, data) {
       data:    data,
       // FIXME: not for GET though?
       // FIXME: or argo?
-      contentType: 'application/json',
-      headers: {
-        // FIXME: should be passed in as argument to make adapter more generic
-        'Accept': 'application/vnd.argo+json'
-      },
-// TODO: optional:
-      crossOrigin: true,
-      //withCredentials: true,
+      contentType:     'application/json',
+      headers:         options.headers,
+      crossOrigin:     options.crossOrigin,
+      withCredentials: options.withCredentials,
       success: (body) => resolve({uri: uri, body: body, status: request.status, headers: getHeaders(request)}),
       // FIXME: parse response iff json content-type
       error:   ()     => reject( {uri: uri, body: request.responseText, status: request.status, headers: getHeaders(request)})
@@ -38,25 +34,50 @@ function dispatch(method, uri, data) {
 
 
 export class Http {
-
-  get(uri, params, options) {
-    return dispatch('get', uri, params);
+  /**
+   * @param {Object} options Base set of options:
+   *  - withCredentials {boolean} Whether to send credentials
+   *  - crossOrigin {boolean} Whether to allow CORS
+   *  - headers {Object} Default headers to send
+   */
+  constructor(baseOptions = {}) {
+    this.baseOptions = baseOptions;
   }
 
-  post(uri, data, implemOptions) {
-    return dispatch('post', uri, JSON.stringify(data));
+  prepareOptions(options) {
+    // TODO: check and normalise types?
+    return Object.mixin(Object.mixin({
+      // TODO: recursively merge, e.g. headers
+      // FIXME: should be passed in as option to make adapter more generic
+      headers: {
+        'Accept': 'application/vnd.argo+json'
+      }
+    }, this.baseOptions), options);
   }
 
-  put(uri, data, implemOptions) {
-    return dispatch('put', uri, JSON.stringify(data));
+  get(uri, params, options = {}) {
+    const opts = this.prepareOptions(options);
+    return dispatch('get', uri, params, opts);
   }
 
-  patch(uri, data, implemOptions) {
-    return dispatch('patch', uri, JSON.stringify(data));
+  post(uri, data, options = {}) {
+    const opts = this.prepareOptions(options);
+    return dispatch('post', uri, JSON.stringify(data), opts);
   }
 
-  delete(uri, implemOptions) {
-    return dispatch('delete', uri);
+  put(uri, data, options = {}) {
+    const opts = this.prepareOptions(options);
+    return dispatch('put', uri, JSON.stringify(data), opts);
+  }
+
+  patch(uri, data, options = {}) {
+    const opts = this.prepareOptions(options);
+    return dispatch('patch', uri, JSON.stringify(data), opts);
+  }
+
+  delete(uri, options = {}) {
+    const opts = this.prepareOptions(options);
+    return dispatch('delete', uri, undefined, opts);
   }
 
 }

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = function(config) {
 
     jspm: {
         loadFiles: ['test/specs/**/*.spec.js'],
-        serveFiles: ['index.js', 'src/**/*.js']
+        serveFiles: ['src/**/*.js']
     },
 
     // list of files / patterns to load in the browser

--- a/test/specs/get.spec.js
+++ b/test/specs/get.spec.js
@@ -109,23 +109,14 @@ describe('Http', () => {
                 requests[0].withCredentials.should.equal(true);
             });
 
-            // TODO: crossOrigin?
-
             it('should pass the headers option to the XHR', () => {
-                // FIXME: fix test
                 http.get('http://example.com', {}, {headers: {'X-Test': 'test'}});
 
                 requests[0].requestHeaders['X-Test'].should.equal('test');
             });
 
-            it.skip('should pass underlying options to reqwest', () => {
-                // FIXME: fix test
-                http.get('http://example.com', {}, {underlying: {url: 'http://hijack.com'}});
+            // TODO: validate type?
 
-                requests[0].url.should.equal('http://hijack.com');
-            });
-
-            // TODO: type?
             // FIXME: always on?
             // it('should pass the crossOrigin option to the XHR', (done) => {
             // });

--- a/test/specs/get.spec.js
+++ b/test/specs/get.spec.js
@@ -1,4 +1,4 @@
-import {Http} from '../../index';
+import {Http} from '../../src/any-http-reqwest';
 
 describe('Http', () => {
 
@@ -98,7 +98,7 @@ describe('Http', () => {
             });
 
             it('should pass withCredentials=false to the XHR by default', () => {
-                http.get('http://example.com', {a: 1});
+                http.get('http://example.com', {});
 
                 requests[0].withCredentials.should.equal(false);
             });

--- a/test/specs/get.spec.js
+++ b/test/specs/get.spec.js
@@ -91,17 +91,6 @@ describe('Http', () => {
                 expect(requests[0].requestBody).to.be.null;
             });
 
-            it.skip('should pass the contentType option to the XHR', () => {
-                // FIXME: or just shouldn't be set for GET?
-            });
-
-            it.skip('should pass the headers option to the XHR', () => {
-                // FIXME: fix test
-                http.get('http://example.com', {}, {headers: {'X-Test': 'ok'}});
-
-                requests[0].headers['X-Test'].should.equal('ok');
-            });
-
             it('should pass withCredentials=false to the XHR by default', () => {
                 http.get('http://example.com', {});
 
@@ -123,8 +112,11 @@ describe('Http', () => {
             // TODO: validate type?
 
             // FIXME: always on?
-            // it('should pass the crossOrigin option to the XHR', (done) => {
-            // });
+            it.skip('should pass the crossOrigin option to the XHR', () => {
+                http.get('http://example.com', {}, {crossOrigin: true});
+
+                // ???
+            });
         });
 
 

--- a/test/specs/get.spec.js
+++ b/test/specs/get.spec.js
@@ -75,7 +75,12 @@ describe('Http', () => {
                 requests[0].url.should.equal('http://example.com?x=1&y=z');
             });
 
-            // TODO: url encode params
+            it('should URL-encode the parameters in the requested uri', () => {
+                http.get('http://example.com', {x: 'hello world', y: '/a=b'});
+
+                requests[0].url.should.equal('http://example.com?x=hello+world&y=%2Fa%3Db');
+            });
+
             // TODO: fail if params not an Object?
             // TODO: ignore if undefined, null or empty Object
             // TODO: fail if options not an Object?

--- a/test/specs/get.spec.js
+++ b/test/specs/get.spec.js
@@ -103,11 +103,19 @@ describe('Http', () => {
                 requests[0].withCredentials.should.equal(false);
             });
 
-            it.skip('should pass the withCredentials option to the XHR', () => {
-                // FIXME: fix test
+            it('should pass the withCredentials option to the XHR', () => {
                 http.get('http://example.com', {}, {withCredentials: true});
 
                 requests[0].withCredentials.should.equal(true);
+            });
+
+            // TODO: crossOrigin?
+
+            it('should pass the headers option to the XHR', () => {
+                // FIXME: fix test
+                http.get('http://example.com', {}, {headers: {'X-Test': 'test'}});
+
+                requests[0].requestHeaders['X-Test'].should.equal('test');
             });
 
             it.skip('should pass underlying options to reqwest', () => {

--- a/test/specs/http.spec.js
+++ b/test/specs/http.spec.js
@@ -1,4 +1,4 @@
-import {Http} from '../../index';
+import {Http} from '../../src/any-http-reqwest';
 
 describe('Http', () => {
 


### PR DESCRIPTION
In particular useful to pass in `withCredentials: true`.

Also adds some tests.

cc @jamesgorrie