### PR TITLE
Object.mixin -> Object.assign

### DIFF
--- a/src/any-http-reqwest.js
+++ b/src/any-http-reqwest.js
@@ -46,7 +46,7 @@ export class Http {
 
   prepareOptions(options) {
     // TODO: check and normalise types?
-    return Object.mixin(Object.mixin({
+    return Object.assign(Object.assign({
       // TODO: recursively merge, e.g. headers
       // FIXME: should be passed in as option to make adapter more generic
       headers: {


### PR DESCRIPTION
`Object.mixin` was dropped from the the ES2015 spec so use Object.assign here.
